### PR TITLE
Update TZToxicZoneServer.c

### DIFF
--- a/ToxicZone/scripts/4_World/classes/SystemTZHandler/Core/TZToxicZoneServer.c
+++ b/ToxicZone/scripts/4_World/classes/SystemTZHandler/Core/TZToxicZoneServer.c
@@ -60,7 +60,7 @@ class TZToxicZoneServer
   }
 
   //-----------------------------------RPC called on server-------------------------------------//
-  void GetToxicStatut(CallType type, ref ParamsReadContext ctx, ref PlayerIdentity sender, ref Object target)
+  void GetToxicStatut(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
   {
    if (!GetGame().IsServer())
      return;
@@ -83,7 +83,7 @@ class TZToxicZoneServer
      #endif
   }
 
-  void GetSickQtyToGive(CallType type, ref ParamsReadContext ctx, ref PlayerIdentity sender, ref Object target)
+  void GetSickQtyToGive(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
   {
    if (!GetGame().IsServer())
      return;


### PR DESCRIPTION
SCRIPT    (W): @"ToxicZone/scripts/4_World/classes\systemtzhandler\core\tztoxiczoneserver.c,63": FIX-ME: Method argument can't be strong reference
SCRIPT    (W): @"ToxicZone/scripts/4_World/classes\systemtzhandler\core\tztoxiczoneserver.c,63": FIX-ME: Method argument can't be strong reference
SCRIPT    (W): @"ToxicZone/scripts/4_World/classes\systemtzhandler\core\tztoxiczoneserver.c,63": FIX-ME: Method argument can't be strong reference
SCRIPT    (W): @"ToxicZone/scripts/4_World/classes\systemtzhandler\core\tztoxiczoneserver.c,86": FIX-ME: Method argument can't be strong reference
SCRIPT    (W): @"ToxicZone/scripts/4_World/classes\systemtzhandler\core\tztoxiczoneserver.c,86": FIX-ME: Method argument can't be strong reference
SCRIPT    (W): @"ToxicZone/scripts/4_World/classes\systemtzhandler\core\tztoxiczoneserver.c,86": FIX-ME: Method argument can't be strong reference